### PR TITLE
remove flutter dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,6 @@ homepage: https://github.com/antonio-nicolau/chaleno
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.17.0"
 
 dependencies:
   http: ">=0.13.0 <1.0.0"


### PR DESCRIPTION
This package doesn't need to depend on Flutter. Removing the dependency enables the package to run in all Dart environments, including Flutter.